### PR TITLE
fix(socat-issue-cert): added socat installation step for issuing SSL …

### DIFF
--- a/marzban/en/examples/issue-ssl-certificate.md
+++ b/marzban/en/examples/issue-ssl-certificate.md
@@ -17,6 +17,16 @@ title: ساخت گواهی SSL
 
 ## دریافت گواهی با acme.sh
 
+- به دلیل استفاده از روش standalone با دستور زیر socat را نصب کتید.
+
+```bash
+apt install curl socat -y
+```
+
+::: tip نکته
+در صورتی که socat را قبلا نصب کرده‌اید، دیگر نیازی به انجام این مرحله نیست.
+:::
+
 - با دستور زیر، [acme.sh](https://github.com/acmesh-official/acme.sh) را نصب کنید.
 
 `YOUR_EMAIL` را به ایمیل خود تغییر دهید.

--- a/marzban/fa/examples/issue-ssl-certificate.md
+++ b/marzban/fa/examples/issue-ssl-certificate.md
@@ -17,6 +17,16 @@ title: ساخت گواهی SSL
 
 ## دریافت گواهی با acme.sh
 
+- به دلیل استفاده از روش standalone با دستور زیر socat را نصب کتید.
+
+```bash
+apt install curl socat -y
+```
+
+::: tip نکته
+در صورتی که socat را قبلا نصب کرده‌اید، دیگر نیازی به انجام این مرحله نیست.
+:::
+
 - با دستور زیر، [acme.sh](https://github.com/acmesh-official/acme.sh) را نصب کنید.
 
 `YOUR_EMAIL` را به ایمیل خود تغییر دهید.

--- a/marzban/ru/examples/issue-ssl-certificate.md
+++ b/marzban/ru/examples/issue-ssl-certificate.md
@@ -17,6 +17,16 @@ title: ساخت گواهی SSL
 
 ## دریافت گواهی با acme.sh
 
+- به دلیل استفاده از روش standalone با دستور زیر socat را نصب کتید.
+
+```bash
+apt install curl socat -y
+```
+
+::: tip نکته
+در صورتی که socat را قبلا نصب کرده‌اید، دیگر نیازی به انجام این مرحله نیست.
+:::
+
 - با دستور زیر، [acme.sh](https://github.com/acmesh-official/acme.sh) را نصب کنید.
 
 `YOUR_EMAIL` را به ایمیل خود تغییر دهید.


### PR DESCRIPTION
<img width="584" alt="image" src="https://github.com/user-attachments/assets/b3d48cc6-a461-41f9-b58b-653befdf19f0">

You need install socat to get SSL Certification in standalone mode,
So, I added installation steps to examples