### PR TITLE
Update marzban-node doc

### DIFF
--- a/marzban/fa/docs/marzban-node.md
+++ b/marzban/fa/docs/marzban-node.md
@@ -5,15 +5,15 @@ title: مرزبان نود
 
 # مرزبان نود
 
-به کمک این آموزش، شما می‌توانید مرزبان نود (Marzban Node) را روی یک یا چندین سرور جانبی راه‌اندازی کرده، و آنها را به پنل مرزبان متصل کنید تا بتوانید از این سرورها در کانفیگ‌های خود استفاده نمایید. مرزبان نود به شما اجازه می‌دهد تا بار ترافیکی را میان سرورهای مختلف پخش کنید و همچنین امکان استفاده از سرورهایی با لوکیشن‌های متفاوت را فراهم می‌کند.
-در ادامه نیز می‌آموزیم که چطور یک سرور نود را به چند پنل مرزبان متصل کنیم.
+مرزبان نود (Marzban Node) به شما اجازه می‌دهد تا بار ترافیکی را میان سرورهای مختلف پخش کنید و همچنین امکان استفاده از سرورهایی با لوکیشن‌های متفاوت را فراهم می‌کند. به کمک مطالب این صفحه شما می‌توانید مرزبان نود را روی یک یا چندین سرور جانبی پیکربندی و راه‌اندازی کرده، و آنها را به پنل مرزبان متصل کنید تا بتوانید از این سرورها در کانفیگ‌های خود استفاده نمایید.
+در ادامه نیز نحوه اتصال نود به چند پنل مرزبان را مشاهده خواهید کرد.
 
 
 ## راه‌اندازی مرزبان نود
 
 - پس از وارد شدن به ترمینال سرور نود، ابتدا با دستور زیر سرور را آپدیت و برنامه‌های مورد نیاز را نصب کنید.
 ```bash
-apt-get update; apt-get upgrade -y; apt-get install curl socat git -y
+apt-get update; apt-get install curl socat git -y
 ```
 
 - داکر را نصب کنید.
@@ -27,13 +27,20 @@ git clone https://github.com/Gozargah/Marzban-node
 mkdir /var/lib/marzban-node 
 ```
 
-- برای برقراری ارتباط امن میان نود و پنل مرزبان، نیاز است در فایل `docker-compose.yml` تغییراتی اعمال کنیم. پس وارد فولدر اصلی مرزبان نود شده، و این فایل را برای ویرایش باز کنید.
+- برای برقراری ارتباط امن میان نود و پنل مرزبان، لازم است در فایل `docker-compose.yml` تغییراتی اعمال شود. پس وارد فولدر اصلی مرزبان نود شده، و این فایل را برای ویرایش باز کنید.
 ```bash
 cd ~/Marzban-node
 nano docker-compose.yml
 ```
+::: tip نکته 
+فایل`docker-compose.yml` به راستای خطوط و فاصله‌گذاری‌ها حساس است. برای صحت‌سنجی پیکربندی خود می‌توانید از ابزار [yamlchecker](https://yamlchecker.com) کمک بگیرید.
+:::
 
-- علامت `#` پشت عبارت `SSL_CLIENT_CERT_FILE` را حذف کنید و این خط را با خط بالا در یک راستا قرار دهید. سپس می‌توانید دو خط مربوط به `SSL_CERT_FILE` و `SSL_KEY_FILE` را حذف کنید. پس از ذخیره تغییرات، در نهایت محتویات فایل شما به این صورت خواهد بود:
+- با حذف `#` از پشت عبارت `SSL_CLIENT_CERT_FILE` آن را از حالت کامنت خارج کنید و این خط را با خط بالا در یک راستا قرار دهید. در صورت تمایل می‌توانید دو خط مربوط به `SSL_CERT_FILE` و `SSL_KEY_FILE` را حذف کنید. 
+
+- اگر از نسخه‌ 0.4.4 و جدیدتر مرزبان استفاده می‌کنید، می‌توانید با فعالسازی پروتکل `rest` پایداری اتصال نودها را بهبود دهید. برای این کار با حذف `#` خط مربوطه را از حالت کامنت خارج کنید.
+
+پس از ذخیره تغییرات، در نهایت محتویات فایل شما به این صورت خواهد بود:
 
 ::: code-group
 ```yml [docker-compose.yml]
@@ -44,22 +51,54 @@ services:
     restart: always
     network_mode: host
 
+    # env_file: .env
     environment:
+      SSL_CERT_FILE: "/var/lib/marzban-node/ssl_cert.pem"
+      SSL_KEY_FILE: "/var/lib/marzban-node/ssl_key.pem"
       SSL_CLIENT_CERT_FILE: "/var/lib/marzban-node/ssl_client_cert.pem"
+      SERVICE_PROTOCOL: "rest"
 
     volumes:
       - /var/lib/marzban-node:/var/lib/marzban-node
 ```
 :::
 
+::: tip نکته
+اگر قصد تغییر پورت‌های اتصال نود به مرزبان را دارید، می‌توانید دو متغیر  `XRAY_API_PORT` و `SERVICE_PORT` را به بخش `environment` در این فایل اضافه کنید و پورت‌های مد نظر خود را قرار دهید.
+([مشاهده نمونه پیکربندی](marzban-node.md#حالت-اول-با-استفاده-از-host-network))
+:::
+
+::: details استفاده از فایل `.env` (اختیاری)
+در صورت تمایل می‌توانید متغیرهای محیطی مرزبان نود را از فایل `.env` تنظیم کنید.
+
+یک کپی از فایل `.env.example` بسازید، آن را برای ویرایش باز کنید و تغییرات مورد نیاز را در این فایل انجام دهید.
+```bash
+cp .env.example .env
+nano .env
+```
+
+فایل `docker-compose.yml` را به صورت زیر تنظیم کنید.
+::: code-group
+```yml [docker-compose.yml]
+services:
+  marzban-node:
+    # build: .
+    image: gozargah/marzban-node:latest
+    restart: always
+    network_mode: host
+    env_file: .env
+    volumes:
+      - /var/lib/marzban-node:/var/lib/marzban-node
+```
+:::
 
 - اکنون در پنل خود از طریق منو وارد بخش `Node Settings` شوید.
 سپس با کلیک بر روی `Add New Mazrban Node` یک نود جدید اضافه کنید.
 
 - با کلیک بر روی دکمه `Show Certificate` سرتیفیکیت مورد نیاز برای اتصال نود را مشاهده خواهید کرد. این سرتیفیکیت را کپی کنید و ادامه مراحل را از ترمینال سرور نود دنبال نمایید.
 
-<img src="https://github.com/mdjvd/gozargah.github.io/assets/116950557/bee4bbf0-f811-4b20-af28-adee270b469d"
-     style="display:block;float:none;margin-left:auto;margin-right:auto;width:47%">
+<img src="https://github.com/user-attachments/assets/397daac8-3cd7-4980-834c-44063b37296f"
+     style="display:block;float:none;margin-left:auto;margin-right:auto;width:50%">
 <br>
 
 - با دستور زیر فایل سرتیفیکیت را ایجاد کرده و محتوای کپی شده را را درون آن قرار دهید.
@@ -77,14 +116,15 @@ docker compose up -d
 
 1. در قسمت `Name` یک نام دلخواه برای نود انتخاب کنید.
 2. در قسمت `Address` آی‌پی سرور نود را قرار دهید.
-3. پورت‌های پیشفرض اتصال نود شامل `Port` و `API Port` را بدون تغییر باقی بگذارید.
-4. در صورتی که می‌خواهید مرزبان نود شما برای همه اینباندها به عنوان یک هاست اضافه شود، تیک `Add this node as a new host for every inbound` را فعال کنید.
+3. پورت‌های پیشفرض اتصال نود شامل `Port` و `API Port` را بدون تغییر باقی بگذارید. مقدار پیشفرض به ترتیب `62050` و `62051` است.
+4. در قسمت `Usage Ratio` می‌توانید ضریب مصرف نود را تغییر دهید. مقدار پیشفرض `1` است.
+5. در صورتی که می‌خواهید آی‌پی سرور نود برای همه اینباندها به عنوان یک هاست اضافه شود، تیک `Add this node as a new host for every inbound` را فعال کنید.
 
 ::: tip نکته
-شما می‌توانید این تیک را غیرفعال کرده، و آی‌پی سرور نود را تنها برای اینباندهای مورد نیاز به عنوان یک هاست در بخش `Host Settings` اضافه کنید.
+شما می‌توانید این تیک را غیرفعال کرده و از سرور نود تنها برای اینباندهای مورد نیاز در بخش `Host Settings` استفاده کنید.
 :::
 
-- در نهایت با کلیک بر روی `Add Node` نود را اضافه کنید. حالا نود آماده استفاده است. شما می‌توانید با مدیریت هاست‌های خود در بخش `Host Settings` آی‌پی سرور نود را برای اینباندهای مورد نظر به کار بگیرید.
+- در نهایت با کلیک بر روی `Add Node` نود را اضافه کنید. حالا مرزبان نود آماده استفاده است. شما می‌توانید با مدیریت هاست‌های خود در بخش `Host Settings` سرور نود را برای اینباندهای مورد نظر به کار بگیرید.
 
 ::: warning توجه
 در صورتی که در سرور نود فایروال فعال کرده‌اید، لازم است پورت‌های اتصال نود به پنل و همچنین پورت‌های اینباندها را در فایروال سرور نود باز کنید.
@@ -92,7 +132,7 @@ docker compose up -d
 
 ## اتصال مرزبان نود به چند پنل
 
-در صورتی که نیاز داشته باشید یک سرور نود را به چند پنل مرزبان متصل کنید، لازم است در فایل `docker-compose.yml` به ازای هر پنل، یک سرویس نود اضافه نمایید. این کار به دو حالت قابل انجام است.
+در صورتی که نیاز دارید یک سرور نود را به چند پنل مرزبان متصل کنید، لازم است در فایل `docker-compose.yml` به ازای هر پنل، یک سرویس نود اضافه نمایید. این کار به دو حالت قابل انجام است.
 
 ::: tip نکته
 شما می‌توانید در هر دو حالت پیکربندی، پورت‌های استفاده شده در نمونه فایل‌های `docker-compose.yml` را مطابق نیاز خود تغییر دهید. همچنین می‌توانید در این فایل به تعداد مورد نیاز، سرویس نود اضافه کنید.
@@ -106,7 +146,7 @@ docker compose up -d
 
 ::: details نمونه پیکربندی فایل `docker-compose.yml`
 ::: code-group
-```yml{11,27} [docker-compose.yml]
+```yml{11,28} [docker-compose.yml]
 services:
   marzban-node-1:
     # build: .
@@ -118,6 +158,7 @@ services:
       SERVICE_PORT: 2000
       XRAY_API_PORT: 2001
       SSL_CLIENT_CERT_FILE: "/var/lib/marzban-node/ssl_client_cert_1.pem"
+      SERVICE_PROTOCOL: "rest"
 
     volumes:
       - /var/lib/marzban-node:/var/lib/marzban-node
@@ -134,6 +175,7 @@ services:
       SERVICE_PORT: 3000
       XRAY_API_PORT: 3001
       SSL_CLIENT_CERT_FILE: "/var/lib/marzban-node/ssl_client_cert_2.pem"
+      SERVICE_PROTOCOL: "rest"
 
     volumes:
       - /var/lib/marzban-node:/var/lib/marzban-node
@@ -166,7 +208,7 @@ docker compose up -d
 
 ::: details نمونه پیکربندی فایل `docker-compose.yml`
 ::: code-group
-```yml{7,25} [docker-compose.yml]
+```yml{7,26} [docker-compose.yml]
 services:
   marzban-node-1:
     image: gozargah/marzban-node:latest
@@ -174,6 +216,7 @@ services:
 
     environment:
       SSL_CLIENT_CERT_FILE: "/var/lib/marzban-node/ssl_client_cert_1.pem"
+      SERVICE_PROTOCOL: "rest"
 
     volumes:
       - /var/lib/marzban-node:/var/lib/marzban-node
@@ -192,6 +235,7 @@ services:
 
     environment:
       SSL_CLIENT_CERT_FILE: "/var/lib/marzban-node/ssl_client_cert_2.pem"
+      SERVICE_PROTOCOL: "rest"
 
     volumes:
       - /var/lib/marzban-node:/var/lib/marzban-node
@@ -216,21 +260,17 @@ services:
 | `API Port`       | 2001      |    3001   |
 | `Inbound Ports` | 2053 <br> 2054 | 2096 <br> 2097 |
 
+::: tip نکته 
+اگر در سرور نود قصد استفاده از وارپ دارید و فایل `docker-compose.yml` را با حالت `Port Mapping` پیکربندی کرده‌اید، می‌بایست وارپ را [با هسته `Xray`](https://gozargah.github.io/marzban/examples/warp#قدم-سوم-فعالسازی-warp-روی-مرزبان) فعال کنید. در صورت استفاده از هسته `Wireguard` وارپ در سرور نود کار نخواهد کرد.
+:::
 
-## آپدیت کردن مرزبان نود
+## آپدیت مرزبان نود
 
-- وارد فولدر مرزبان نود می شویم.
+برای آپدیت مرزبان نود، دستورات زیر را به ترتیب اجرا کنید.
+
 ```bash
-cd Marzban-node
-```
-
-- با دستور زیر مرزبان نود را آپدیت می کنیم.
-```bash
+cd ~/Marzban-node
 docker compose pull
-```
-
-- در نهایت با دستور زیر مرزبان نود را ریستارت می کنیم.
-```bash
 docker compose down --remove-orphans; docker compose up -d
 ```
 
@@ -238,29 +278,81 @@ docker compose down --remove-orphans; docker compose up -d
 ## نکات تکمیلی
 
 ::: tip نکته اول
- اگر برای مدیریت بهتر نودها می‌خواهید برای هر نود یک اینباند مجزا در نظر بگیرید، لازم است که اینباند جدیدی با `Tag` و `Port` متفاوت در `Core Settings` اضافه کنید.
-:::
-
-::: tip نکته دوم
-اگر در سرور نود قصد استفاده از وارپ دارید و فایل `docker-compose.yml` را با حالت دوم پیکربندی کرده‌اید، می‌بایست وارپ را [با هسته `Xray`](https://gozargah.github.io/marzban/examples/warp#قدم-سوم-فعالسازی-warp-روی-مرزبان) فعال کنید. در صورت استفاده از هسته `Wireguard` وارپ در سرور نود کار نخواهد کرد.
-:::
-
-::: tip نکته سوم
-چنان‌چه قصد استفاده از کانفیگ‌های TLSدار را دارید، می‌بایست برای دامنه خود در سرور نود سرتیفیکیت گرفته، سپس آن را به سرور اصلی منتقل کنید و مسیر فایل‌های سرتیفیکیت را در اینباند وارد نمایید. همچنین به جای چند سرتیفیکیت برای چند سابدامین، می‌توانید یک سرتیفیکیت `Wildcard` برای دامنه اصلی خود بگیرید تا برای همه سابدامین‌ها مورد استفاده قرار گیرد.
-:::
-
-::: tip نکته چهارم
-فایل`docker-compose.yml` به راستای خطوط و فاصله‌گذاری‌ها حساس است. برای صحت‌سنجی پیکربندی خود می‌توانید از ابزار [yamlchecker](https://yamlchecker.com) کمک بگیرید.
-:::
-
-::: tip نکته پنجم
 در صورت اعمال تغییر در فایل `docker-compose.yml` با دستور زیر مرزبان نود را ری‌استارت کنید.
 ```bash
 cd ~/Marzban-node
 docker compose down --remove-orphans; docker compose up -d
 ```
+
+برای مشاهده لاگ‌های مرزبان نود از دستور زیر استفاده کنید.
+```bash
+cd ~/Marzban-node
+docker compose logs -f
+```
 :::
 
-::: tip نکته ششم
-در خصوص ورژن Xray اگر مرزبان نود روی ورژن آخر نبود و خواستین دستی Upgrade کنین به ورژن بالاتر یا به هر دلیلی خواستین Downgrade کنین به نسخه پایین تر از طریق داکیومنت تغییر ورژن Xray-core می تونین انجام بدین.
+::: tip نکته دوم
+برای تغییر نسخه `Xray-core` مرزبان نود، به آموزش [تغییر ورژن Xray-core](/examples/change-xray-version.md) رجوع کنید.
+:::
+
+::: tip نکته سوم
+ برای مدیریت بهتر بر دسترسی کاربران به نودهای مختلف، می‌توانید برای هر نود یک اینباند مجزا با `Tag` و `Port` متفاوت در `Core Settings` اضافه کنید و اینباند مد نظر را برای کاربر فعال یا غیرفعال کنید.
+:::
+
+::: tip نکته چهارم
+چنان‌چه قصد استفاده از کانفیگ‌های TLSدار را دارید، می‌بایست برای دامنه خود در سرور نود سرتیفیکیت گرفته، سپس آن را به سرور اصلی منتقل کنید و مسیر فایل‌های سرتیفیکیت را در اینباند وارد نمایید. همچنین به جای چند سرتیفیکیت برای چند سابدامین، می‌توانید یک سرتیفیکیت `Wildcard` برای دامنه اصلی خود بگیرید تا برای همه سابدامین‌ها مورد استفاده قرار گیرد.
+:::
+
+
+
+## پیکربندی  
+
+
+لیست متغیرهای محیطی مرزبان نود را در این قسمت مشاهده می‌کنید. شما می‌توانید تمام این متغیرها در فایل `docker-compose.yml` و یا `.env` مربوط به مرزبان نود مقداردهی کنید.
+
+::: details Environment Variables
+### SERVICE_PORT
+- مقدار پیش‌فرض: `62050`
+
+پورت سرویس مرزبان نود
+
+### XRAY_API_PORT 
+- مقدار پیش‌فرض: `62051`
+
+پورت Xray Api
+
+### XRAY_EXECUTABLE_PATH 
+- مقدار پیش‌فرض: `/usr/local/bin/xray`
+
+آدرس فایل اجرایی xray
+
+### XRAY_ASSETS_PATH 
+- مقدار پیش‌فرض: `/usr/local/share/xray`
+
+آدرس پوشه فایل های asset برای xray (فایل های `geoip.dat` و `geosite.dat`)
+
+### SSL_CERT_FILE 
+- مقدار پیش‌فرض: `/var/lib/marzban-node/ssl_cert.pem`
+
+آدرس فایل certificate گواهی SSL
+
+### SSL_KEY_FILE
+- مقدار پیش‌فرض: `/var/lib/marzban-node/ssl_key.pem`
+
+آدرس فایل key گواهی SSL
+
+### SSL_CLIENT_CERT_FILE 
+
+آدرس فایل certificate کاربر 
+
+### DEBUG  
+- مقدار پیش‌فرض: `False`
+
+فعالسازی حالت توسعه (development)
+
+### SERVICE_PROTOCOL  
+- مقدار پیش‌فرض: `rpyc`
+
+پروتکل سرویس مرزبان نود
+
 :::


### PR DESCRIPTION
- rest protocol is now the default
- removed unnecessary parts
- moved tips to their right spots
- added .env configuration (optional)
- added Marzban-node environment variables section
- small fixes

I will add node installation with the script as well as manual installation (without docker) later.